### PR TITLE
Add quote on scalar

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -17,4 +17,4 @@ services:
     bd_guzzle_site_authenticator.site_config_builder.array:
         class: BD\GuzzleSiteAuthenticator\SiteConfig\ArraySiteConfigBuilder
         arguments:
-            - %bd_guzzle_site_authenticator.site_config%
+            - "%bd_guzzle_site_authenticator.site_config%"


### PR DESCRIPTION
> Not quoting the scalar "%bd_guzzle_site_authenticator.site_config%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0