### PR TITLE
Pass through if login required but not username filled

### DIFF
--- a/lib/Guzzle/AuthenticatorSubscriber.php
+++ b/lib/Guzzle/AuthenticatorSubscriber.php
@@ -54,7 +54,7 @@ class AuthenticatorSubscriber implements SubscriberInterface
 
         $client = $event->getClient();
         $authenticator = $this->authenticatorFactory->buildFromSiteConfig($config);
-        if (!$authenticator->isLoggedIn($client)) {
+        if (!$authenticator->isLoggedIn($client) || is_null($config->getUsername())) {
             $emitter = $client->getEmitter();
             $emitter->detach($this);
             $authenticator->login($client);
@@ -68,7 +68,7 @@ class AuthenticatorSubscriber implements SubscriberInterface
             return;
         }
 
-        if (!$config->requiresLogin()) {
+        if (!$config->requiresLogin() || is_null($config->getUsername())) {
             return;
         }
 


### PR DESCRIPTION
Hi Bertand,
I'm using this lib with wallabag, as you might know, but encountering an issue getting nextinpact content because I haven't a premium account. When wallabag fetch the article, it seems like guzzle site authenticator tried to login and never gets the accessible public content.
I thought it could be a good idea to look at the username but it is an open thinking.
Thanks anyway.